### PR TITLE
enable opacity/transparant rendering

### DIFF
--- a/examples/opengl_test.cpp
+++ b/examples/opengl_test.cpp
@@ -49,10 +49,13 @@ int main(int argc, char* argv[]) {
       &texels[0], texWidth, texHeight);
 
   int shape = app.register_cube_shape(10, 10, 0.01, textureIndex, 40);  //, 10);
-  app.m_renderer->register_graphics_instance(shape, pos, orn, color, scaling);
-  pos.setValue(0, 0, 2);
+  
+  int inst = app.m_renderer->register_graphics_instance(shape, pos, orn, color, scaling);
+  //app.m_renderer->write_single_instance_color_to_cpu(color, inst);
+  pos.setValue(0, 0, 1);
   shape = app.register_graphics_unit_sphere_shape(SPHERE_LOD_HIGH);
-  app.m_renderer->register_graphics_instance(shape, pos, orn, color, scaling);
+  float opacity = 0.7;
+  app.m_renderer->register_graphics_instance(shape, pos, orn, color, scaling, opacity);
 
 
   tinyobj::attrib_t attrib;

--- a/examples/opengl_window/tiny_gl_instancing_renderer.cpp
+++ b/examples/opengl_window/tiny_gl_instancing_renderer.cpp
@@ -902,7 +902,7 @@ int TinyGLInstancingRenderer::register_graphics_instance_internal(
     c.setInt(newUid);
     m_data->m_instance_scale_ptr[index * 4 + 3] = c.getFloat();
 
-    if (0)  // color[3] < 1 && color[3] > 0)
+    if (opacity < 1 && opacity > 0)
     {
       gfxObj->m_flags |= B3_INSTANCE_TRANSPARANCY;
     }
@@ -928,11 +928,11 @@ int TinyGLInstancingRenderer::register_graphics_instance(
   assert(m_graphicsInstances.size() < m_data->m_maxNumObjectCapacity - 1);
   if (shapeIndex == (m_graphicsInstances.size() - 1)) {
     register_graphics_instance_internal(newUid, position, quaternion, color,
-                                        scaling);
+                                        scaling, opacity);
   } else {
     int srcIndex = m_data->m_totalNumInstances++;
     pg->m_internalInstanceIndex = srcIndex;
-
+    
     m_data->m_instance_positions_ptr[srcIndex * 4 + 0] = position[0];
     m_data->m_instance_positions_ptr[srcIndex * 4 + 1] = position[1];
     m_data->m_instance_positions_ptr[srcIndex * 4 + 2] = position[2];

--- a/python/pytinydiffsim.cc
+++ b/python/pytinydiffsim.cc
@@ -22,6 +22,7 @@
 #include "fix64_scalar.h"
 #include "tiny_double_utils.h"
 #include "tiny_matrix3x3.h"
+#include "tiny_matrix_x.h"
 #include "tiny_mb_constraint_solver_spring.h"
 #include "tiny_multi_body.h"
 #include "tiny_pose.h"
@@ -132,6 +133,18 @@ PYBIND11_MODULE(pytinydiffsim, m) {
       .def("apply_impulse", &TinyRigidBody<double, DoubleUtils>::apply_impulse)
       .def("clear_forces", &TinyRigidBody<double, DoubleUtils>::clear_forces)
       .def("integrate", &TinyRigidBody<double, DoubleUtils>::integrate);
+
+  py::class_<TinyMatrixXxX<double, DoubleUtils>>(m, "TinyMatrixXxX")
+      .def(py::init<int, int>())
+      .def("inversed", &TinyMatrixXxX<double, DoubleUtils>::inversed)
+      .def("set_zero", &TinyMatrixXxX<double, DoubleUtils>::set_zero)
+      .def("print", &TinyMatrixXxX<double, DoubleUtils>::print)
+      .def("__getitem__", [](const TinyMatrixXxX<double, DoubleUtils>& a,
+          int row, int col) { return a(row,col); })
+      .def_readonly("num_rows", &TinyMatrixXxX<double, DoubleUtils>::m_rows)
+      .def_readonly("num_columns", &TinyMatrixXxX<double, DoubleUtils>::m_cols)
+      
+      ;
 
   py::class_<TinyMatrix3x3<double, DoubleUtils>>(m, "TinyMatrix3x3")
       .def(py::init<>())
@@ -253,7 +266,7 @@ PYBIND11_MODULE(pytinydiffsim, m) {
            &TinyMultiBody<double, DoubleUtils>::set_position)
       .def("get_world_transform",
            &TinyMultiBody<double, DoubleUtils>::get_world_transform)
-
+      .def("mass_matrix", &TinyMultiBody<double, DoubleUtils>::mass_matrix1)
       .def("attach_link", &TinyMultiBody<double, DoubleUtils>::attach_link)
       .def("forward_kinematics",
            &TinyMultiBody<double, DoubleUtils>::forward_kinematics1)
@@ -268,6 +281,8 @@ PYBIND11_MODULE(pytinydiffsim, m) {
       .def("point_jacobian",
            &TinyMultiBody<double, DoubleUtils>::point_jacobian1)
       .def("bias_forces", &TinyMultiBody<double, DoubleUtils>::bias_forces)
+      .def_property_readonly("num_dofs", &TinyMultiBody<double, DoubleUtils>::dof)
+      .def_property_readonly("num_dofs_qd", &TinyMultiBody<double, DoubleUtils>::dof_qd)
       .def_readwrite("q", &TinyMultiBody<double, DoubleUtils>::m_q)
       .def_readwrite("links", &TinyMultiBody<double, DoubleUtils>::m_links)
       .def_readwrite("qd", &TinyMultiBody<double, DoubleUtils>::m_qd)

--- a/tiny_multi_body.h
+++ b/tiny_multi_body.h
@@ -799,6 +799,9 @@ class TinyMultiBody {
    * matrix. M must be a properly initialized square matrix of size dof_qd().
    */
   void mass_matrix(TinyMatrixXxX* M) { mass_matrix(m_q, M); }
+  void mass_matrix1(TinyMatrixXxX* M) { 
+      mass_matrix(m_q, M); 
+  }
 
   /**
    * LTDL factorization exploiting branch-induced sparsity pattern in


### PR DESCRIPTION
expose mass_matrix computation in Python, example snippet:

dofs_qd = mb.num_dofs_qd
print("dofs_qd=",dofs_qd)
mass_matrix = dp.TinyMatrixXxX(dofs_qd,dofs_qd)
mass_matrix.set_zero()
rows = mass_matrix.num_rows
cols = mass_matrix.num_columns
mb.mass_matrix(mass_matrix)
print("rows =",rows )
print("cols =",cols )
mass_matrix.print("mass_matrix")