### PR TITLE
Add NeuralNetwork constructor to load from a trained .pt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,16 @@ else(Eigen3_FOUND)
     endif(USE_EIGEN_FALLBACK)
 endif (Eigen3_FOUND)
 
+OPTION(USE_TORCH "Use LibTorch" OFF)
+IF (USE_TORCH)
+    find_package(Torch)
+    if (Torch_FOUND)
+        message("FOUND TORCH")
+        message("Torch directories: ${TORCH_LIBRARIES}")
+    endif (Torch_FOUND)
+    add_definitions(-DUSE_TORCH)
+ENDIF (USE_TORCH)
+
 add_definitions(-DTDS_HOME="${CMAKE_CURRENT_LIST_DIR}")
 message("Setting TDS_HOME=${CMAKE_CURRENT_LIST_DIR}")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -109,3 +109,8 @@ add_executable(meshcat_zmq_example meshcat_zmq_example.cpp ${TDS_HDRS})
 target_link_libraries(meshcat_zmq_example  ${MESHCAT_LIBRARIES})
 target_include_directories(meshcat_zmq_example PRIVATE ../third_party ../third_party/nlohmann/include ../src)
 
+IF (USE_TORCH)
+    add_executable(load_pytorch_network load_pytorch_network.cpp ${TDS_HDRS})
+    target_link_libraries(load_pytorch_network "${TORCH_LIBRARIES}")
+    target_include_directories(load_pytorch_network PRIVATE ../src)
+ENDIF (USE_TORCH)

--- a/examples/load_pytorch_network.cpp
+++ b/examples/load_pytorch_network.cpp
@@ -1,0 +1,69 @@
+// Example to load a PyTorch trained model .pt file into a TDS NeuralNetwork.
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <sstream>
+
+#include <torch/script.h>
+
+#include "math/neural_network.hpp"
+#include "math/tiny/tiny_double_utils.h"
+#include "math/tiny/tiny_algebra.hpp"
+
+using tds::NeuralNetwork;
+using tds::NeuralNetworkActivation;
+
+int main(int argc, const char* argv[]) {
+  if (argc != 2) {
+    std::cerr
+        << "usage: load_pytorch_network <path-to-exported-script-module>\n";
+    return -1;
+  }
+
+  torch::jit::script::Module module;
+  try {
+    // Deserialize the ScriptModule from a file using torch::jit::load().
+    module = torch::jit::load(argv[1]);
+  }
+  catch (const c10::Error& e) {
+    std::cerr << "error loading the model\n" << e.msg() << std::endl;
+    return -1;
+  }
+
+  std::cout << "Torch model loaded\n";
+
+  NeuralNetwork<TinyAlgebra<double, TINY::DoubleUtils>> net(module);
+
+  // Test to verify that the LibTorch model and TDS model would return similar
+  // results given the same input.
+  int input_dim = net.input_dim();
+
+  std::vector<double> input_vec = {
+    0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  1.47403184e-04,
+   -2.94704954e-02,  0.00000000e+00,  3.05853542e-02,  9.51030292e-03,
+    5.17256707e-02,  1.00000000e+00,  1.00000000e+00,  1.00000000e+00,
+    1.00000000e+00,  2.10564360e-01, -7.85591453e-03, -2.40782738e-01,
+    6.08715266e-02,  2.03281105e-01, -2.38092959e-01, -8.93045291e-02,
+   -2.17512503e-01, -2.31911838e-01, -2.38997698e-01, -6.37538265e-03,
+   -2.29222238e-01,  4.50000000e-01,  4.50000000e-01,  4.50000000e-01,
+    4.50000000e-01,  0.00000000e+00,  0.00000000e+00,  2.40000000e-01,
+    0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+    0.00000000e+00
+  };
+
+  // torch
+  std::vector<torch::jit::IValue> torch_input;
+  torch_input.push_back(torch::tensor(input_vec, torch::dtype(torch::kDouble)));
+  std::cout << "torch output: " << module.forward(torch_input) << std::endl;
+  // tds
+  std::vector<double> output;
+  net.compute(input_vec, output);
+  std::cout << "tds output: ";
+  for (auto item: output) {
+    std::cout << item << ", ";
+  }
+  std::cout << std::endl;
+
+}


### PR DESCRIPTION
Tested: this new constructor is tested to work w/ the MPC neural network (generated [here](https://github.com/uscresl/hybrid-sim-exp/tree/master/neural_mpc)) we used for the Laikago locomotion experiment. It loads the .pt model successfully and produces close results as the torch model, given the same input from [combined_real_robot_mpc_inputs.npy](https://github.com/uscresl/hybrid-sim-exp/blob/master/neural_mpc/mpc_controller/combined_real_robot_mpc_inputs.npy).

The example file includes only one example input from the dataset. The .npy file was directly into the cpp file b/c it adds additional dependency and it's non-trivial. I manually extracted a few example input vectors via python and ran this example for verification.