### PR TITLE
opengl_urdf_visualizer, allow rendering of TINY_SPHERE_TYPE, TINY_BOX…

### DIFF
--- a/data/humanoid_updated_inertia.urdf
+++ b/data/humanoid_updated_inertia.urdf
@@ -1,0 +1,378 @@
+<robot name="dumpUrdf">
+	<link name="base" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0 0 0" />
+			 <mass value = "0.0001" />
+			<inertia ixx = "0.0001" ixy = "0" ixz = "0" iyy = "0.0001" iyz = "0" izz = "0.0001" />
+		</inertial>
+	</link>
+	<link name="root" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.280000 0.000000" />
+			 <mass value = "6.000000" />
+			<inertia ixx="0.31104" ixy="0" ixz="0" iyy="0.31104" iyz="0" izz="0.31104"/>
+		</inertial>
+			<visual>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.280000 0.000000" />
+			<geometry>
+				<sphere radius = "0.360000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.280000 0.000000" />
+			<geometry>
+				<sphere radius = "0.360000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="root" type="fixed" >
+		<parent link = "base" />
+		<child link="root" />
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+	</joint>
+	<link name="chest" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.480000 0.000000" />
+			 <mass value = "14.000000" />
+			<inertia ixx="1.08416" ixy="0" ixz="0" iyy="1.08416" iyz="0" izz="1.08416"/>
+		</inertial>
+		<visual>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.480000 0.000000" />
+			<geometry>
+				<sphere radius = "0.440000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.480000 0.000000" />
+			<geometry>
+				<sphere radius = "0.440000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="chest" type="spherical" >
+		<parent link="root" />
+		<child link="chest" />
+				<origin rpy = "0 0 0" xyz = "0.000000 0.944604 0.000000" />
+	</joint>
+	<link name="neck" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.700000 0.000000" />
+			 <mass value = "2.000000" />
+			<inertia ixx="0.13448" ixy="0" ixz="0" iyy="0.13448" iyz="0" izz="0.13448"/>
+		</inertial>
+		<visual>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.700000 0.000000" />
+			<geometry>
+				<sphere radius = "0.410000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.700000 0.000000" />
+			<geometry>
+				<sphere radius = "0.410000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="neck" type="spherical" >
+		<parent link="chest" />
+		<child link="neck" />
+				<origin rpy = "0 0 0" xyz = "0.000000 0.895576 0.000000" />
+	</joint>
+	<link name="right_hip" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.840000 0.000000" />
+			 <mass value = "4.500000" />
+			<inertia ixx="1.08432" ixy="0" ixz="0" iyy="0.14652" iyz="0" izz="1.08432"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.840000 0.000000" />
+			<geometry>
+				<capsule length="1.200000" radius="0.220000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.840000 0.000000" />
+			<geometry>
+				<capsule length="1.200000" radius="0.220000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="right_hip" type="spherical" >
+		<parent link="root" />
+		<child link="right_hip" />
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.339548" />
+	</joint>
+	<link name="right_knee" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.800000 0.000000" />
+			 <mass value = "3.000000" />
+			<inertia ixx="0.71444" ixy="0" ixz="0" iyy="0.08080" iyz="0" izz="0.71444"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.800000 0.000000" />
+			<geometry>
+				<capsule length="1.240000" radius="0.200000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.800000 0.000000" />
+			<geometry>
+				<capsule length="1.240000" radius="0.200000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="right_knee" type="revolute" >
+		<parent link="right_hip" />
+		<child link="right_knee" />
+		 <limit effort="1000.0" lower="-3.14" upper="0." velocity="0.5"/>
+			<origin rpy = "0 0 0" xyz = "0.000000 -1.686184 0.000000" />
+		<axis xyz = "0.000000 0.000000 1.000000" />
+	</joint>
+	<link name="right_ankle" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.180000 -0.090000 0.000000" />
+			 <mass value = "1.000000" />
+			<inertia ixx="0.01483" ixy="0" ixz="0" iyy="0.05257" iyz="0" izz="0.04581"/>
+		</inertial>
+		<visual>
+				<origin rpy = "0 0 0" xyz = "0.180000 -0.090000 0.000000" />
+			<geometry>
+				<box size="0.708000 0.220000 0.360000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.180000 -0.090000 0.000000" />
+			<geometry>
+				<box size="0.708000 0.220000 0.360000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="right_ankle" type="spherical" >
+		<parent link="right_knee" />
+		<child link="right_ankle" />
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.639480 0.000000" />
+	</joint>
+	<link name="right_shoulder" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.560000 0.000000" />
+			 <mass value = "1.500000" />
+			<inertia ixx="0.16272" ixy="0" ixz="0" iyy="0.03276" iyz="0" izz="0.16272"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.560000 0.000000" />
+			<geometry>
+				<capsule length="0.720000" radius="0.180000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.560000 0.000000" />
+			<geometry>
+				<capsule length="0.720000" radius="0.180000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="right_shoulder" type="spherical" >
+		<parent link="chest" />
+		<child link="right_shoulder" />
+				<origin rpy = "0 0 0" xyz = "-0.096200 0.974000 0.732440" />
+	</joint>
+	<link name="right_elbow" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.480000 0.000000" />
+			 <mass value = "1.000000" />
+			<inertia ixx="0.07056" ixy="0" ixz="0" iyy="0.01728" iyz="0" izz="0.07056"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.480000 0.000000" />
+			<geometry>
+				<capsule length="0.540000" radius="0.160000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.480000 0.000000" />
+			<geometry>
+				<capsule length="0.540000" radius="0.160000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="right_elbow" type="revolute" >
+		<parent link="right_shoulder" />
+		<child link="right_elbow" />
+		<limit effort="1000.0" lower="0" upper="3.14" velocity="0.5"/>
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.099152 0.000000" />
+		<axis xyz = "0.000000 0.000000 1.000000" />
+	</joint>
+	<link name="right_wrist" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+			 <mass value = "0.500000" />
+			<inertia ixx="0.00512" ixy="0" ixz="0" iyy="0.00512" iyz="0" izz="0.00512"/>
+		</inertial>
+		<visual>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+			<geometry>
+				<sphere radius = "0.160000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+			<geometry>
+				<sphere radius = "0.160000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="right_wrist" type="fixed" >
+		<parent link="right_elbow" />
+		<child link="right_wrist" />
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.035788 0.000000" />
+	</joint>
+	<link name="left_hip" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.840000 0.000000" />
+			 <mass value = "4.500000" />
+			<inertia ixx="1.08432" ixy="0" ixz="0" iyy="0.14652" iyz="0" izz="1.08432"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.840000 0.000000" />
+			<geometry>
+				<capsule length="1.200000" radius="0.220000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.840000 0.000000" />
+			<geometry>
+				<capsule length="1.200000" radius="0.220000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="left_hip" type="spherical" >
+		<parent link="root" />
+		<child link="left_hip" />
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 -0.339548" />
+	</joint>
+	<link name="left_knee" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.800000 0.000000" />
+			 <mass value = "3.000000" />
+			<inertia ixx="0.71444" ixy="0" ixz="0" iyy="0.08080" iyz="0" izz="0.71444"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.800000 0.000000" />
+			<geometry>
+				<capsule length="1.240000" radius="0.200000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.800000 0.000000" />
+			<geometry>
+				<capsule length="1.240000" radius="0.200000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="left_knee" type="revolute" >
+		<parent link="left_hip" />
+		<child link="left_knee" />
+		<limit effort="1000.0" lower="-3.14" upper="0." velocity="0.5"/>
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.686184 0.000000" />
+		<axis xyz = "0.000000 0.000000 1.000000" />
+	</joint>
+	<link name="left_ankle" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.180000 -0.090000 0.000000" />
+			 <mass value = "1.000000" />
+			<inertia ixx="0.01483" ixy="0" ixz="0" iyy="0.05257" iyz="0" izz="0.04581"/>
+		</inertial>
+		<visual>
+				<origin rpy = "0 0 0" xyz = "0.180000 -0.090000 0.000000" />
+			<geometry>
+				<box size="0.708000 0.220000 0.360000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.180000 -0.090000 0.000000" />
+			<geometry>
+				<box size="0.708000 0.220000 0.360000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="left_ankle" type="spherical" >
+		<parent link="left_knee" />
+		<child link="left_ankle" />
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.639480 0.000000" />
+	</joint>
+	<link name="left_shoulder" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.560000 0.000000" />
+			 <mass value = "1.500000" />
+			<inertia ixx="0.16272" ixy="0" ixz="0" iyy="0.03276" iyz="0" izz="0.16272"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.560000 0.000000" />
+			<geometry>
+				<capsule length="0.720000" radius="0.180000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.560000 0.000000" />
+			<geometry>
+				<capsule length="0.720000" radius="0.180000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="left_shoulder" type="spherical" >
+		<parent link="chest" />
+		<child link="left_shoulder" />
+				<origin rpy = "0 0 0" xyz = "-0.096200 0.974000 -0.732440" />
+	</joint>
+	<link name="left_elbow" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 -0.480000 0.000000" />
+			 <mass value = "1.000000" />
+			<inertia ixx="0.07056" ixy="0" ixz="0" iyy="0.01728" iyz="0" izz="0.07056"/>
+		</inertial>
+		<visual>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.480000 0.000000" />
+			<geometry>
+				<capsule length="0.540000" radius="0.160000"/>
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "-1.570796 0 0" xyz = "0.000000 -0.480000 0.000000" />
+			<geometry>
+				<capsule length="0.540000" radius="0.160000"/>
+			</geometry>
+		</collision>
+	</link>
+	<joint name="left_elbow" type="revolute" >
+		<parent link="left_shoulder" />
+		<child link="left_elbow" />
+		<limit effort="1000.0" lower="0" upper="3.14" velocity="0.5"/>
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.099152 0.000000" />
+		<axis xyz = "0.000000 0.000000 1.000000" />
+	</joint>
+	<link name="left_wrist" >
+		<inertial>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+			 <mass value = "0.500000" />
+			<inertia ixx="0.00512" ixy="0" ixz="0" iyy="0.00512" iyz="0" izz="0.00512"/>
+		</inertial>
+		<visual>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+			<geometry>
+				<sphere radius = "0.160000" />
+			</geometry>
+		</visual>
+		<collision>
+				<origin rpy = "0 0 0" xyz = "0.000000 0.000000 0.000000" />
+			<geometry>
+				<sphere radius = "0.160000" />
+			</geometry>
+		</collision>
+	</link>
+	<joint name="left_wrist" type="fixed" >
+		<parent link="left_elbow" />
+		<child link="left_wrist" />
+				<origin rpy = "0 0 0" xyz = "0.000000 -1.035788 0.000000" />
+	</joint>
+</robot>
+ 

--- a/examples/opengl_urdf_visualizer.h
+++ b/examples/opengl_urdf_visualizer.h
@@ -162,20 +162,64 @@ struct OpenGLUrdfVisualizer {
       b2v.inertia_rpy = link.urdf_inertial.origin_rpy;
       int color_rgb = 0xffffff;
       double world_pos[3] = {0, 0, 0};
-      if (v.geometry.geom_type == ::tds::TINY_MESH_TYPE) {
-        // printf("mesh filename=%s\n", v.geom_meshfilename.c_str());
-        std::string obj_filename;
-        std::string org_obj_filename = m_path_prefix + v.geometry.mesh.file_name;
-        if (::tds::FileUtils::find_file(org_obj_filename, obj_filename))
-        {
-            ::TINY::TinyVector3f pos(0, 0, 0);
-            ::TINY::TinyVector3f scaling(Algebra::to_double(v.geometry.mesh.scale[0]), 
-                Algebra::to_double(v.geometry.mesh.scale[1]), 
-                Algebra::to_double(v.geometry.mesh.scale[2]));
-            ::TINY::TinyQuaternionf orn(0, 0, 0, 1);
-            load_obj_shapes(obj_filename, b2v.visual_shape_uids, b2v.shape_colors);
-        }
+      switch(v.geometry.geom_type)
+      {
+        case ::tds::TINY_MESH_TYPE: 
+          {
+              // printf("mesh filename=%s\n", v.geom_meshfilename.c_str());
+              std::string obj_filename;
+              std::string org_obj_filename = m_path_prefix + v.geometry.mesh.file_name;
+              if(::tds::FileUtils::find_file(org_obj_filename,obj_filename))
+              {
+                  ::TINY::TinyVector3f pos(0,0,0);
+                  ::TINY::TinyVector3f scaling(Algebra::to_double(v.geometry.mesh.scale[0]),
+                      Algebra::to_double(v.geometry.mesh.scale[1]),
+                      Algebra::to_double(v.geometry.mesh.scale[2]));
+                  ::TINY::TinyQuaternionf orn(0,0,0,1);
+                  load_obj_shapes(obj_filename,b2v.visual_shape_uids,b2v.shape_colors);
+              }
+              break;
+          }
+          case TINY_SPHERE_TYPE:
+          {
+              //int shape_id = m_opengl_app.register_graphics_unit_sphere_shape(SPHERE_LOD_HIGH);
+              int up_axis = 2;
+              int shape_id = m_opengl_app.register_graphics_capsule_shape(v.geometry.sphere.radius,0,up_axis,-1);
+              b2v.visual_shape_uids.push_back(shape_id);
+              ::TINY::TinyVector3f color(1,1,1);
+              b2v.shape_colors.push_back(color);
+              break;
+          }
+          case TINY_CAPSULE_TYPE:
+          {
+              float radius = v.geometry.capsule.radius;
+              float half_height = (v.geometry.capsule.length)*0.5;
+              int up_axis = 2;
+              int shape_id = m_opengl_app.register_graphics_capsule_shape(radius,half_height,up_axis,-1);
+              b2v.visual_shape_uids.push_back(shape_id);
+              ::TINY::TinyVector3f color(1,1,1);
+              b2v.shape_colors.push_back(color);
+              break;
+          }
+          case TINY_BOX_TYPE:
+          {
+              float half_extentsx = 0.5*v.geometry.box.extents[0];
+              float half_extents_y = 0.5*v.geometry.box.extents[1];
+              float half_extents_z = 0.5*v.geometry.box.extents[2];
+              int shape_id = m_opengl_app.register_cube_shape(half_extentsx,half_extents_y,half_extents_z);
+              b2v.visual_shape_uids.push_back(shape_id);
+              ::TINY::TinyVector3f color(1,1,1);
+              b2v.shape_colors.push_back(color);
+
+              break;
+          }
+          default:
+          {
+              std::cout << "Unsupported shape type" << std::endl;
+          }
       }
+
+      
       v.visual_shape_uid = m_uid;
       m_b2vis[m_uid++] = b2v;
     }
@@ -261,6 +305,7 @@ struct OpenGLUrdfVisualizer {
     m_opengl_app.m_renderer->set_light_specular_intensity(specular);
     DrawGridData data;
     data.upAxis = 2;
+    data.drawAxis = true;
     m_opengl_app.draw_grid(data);
     //const char* bla = "3d label";
     //m_opengl_app.draw_text_3d(bla, 0, 0, 1, 1);

--- a/examples/opengl_urdf_visualizer.h
+++ b/examples/opengl_urdf_visualizer.h
@@ -180,20 +180,20 @@ struct OpenGLUrdfVisualizer {
               }
               break;
           }
-          case TINY_SPHERE_TYPE:
+          case ::tds::TINY_SPHERE_TYPE:
           {
               //int shape_id = m_opengl_app.register_graphics_unit_sphere_shape(SPHERE_LOD_HIGH);
               int up_axis = 2;
-              int shape_id = m_opengl_app.register_graphics_capsule_shape(v.geometry.sphere.radius,0,up_axis,-1);
+              int shape_id = m_opengl_app.register_graphics_capsule_shape(Algebra::to_double(v.geometry.sphere.radius),0.,up_axis,-1);
               b2v.visual_shape_uids.push_back(shape_id);
               ::TINY::TinyVector3f color(1,1,1);
               b2v.shape_colors.push_back(color);
               break;
           }
-          case TINY_CAPSULE_TYPE:
+          case ::tds::TINY_CAPSULE_TYPE:
           {
-              float radius = v.geometry.capsule.radius;
-              float half_height = (v.geometry.capsule.length)*0.5;
+              float radius = Algebra::to_double(v.geometry.capsule.radius);
+              float half_height = Algebra::to_double(v.geometry.capsule.length)*0.5;
               int up_axis = 2;
               int shape_id = m_opengl_app.register_graphics_capsule_shape(radius,half_height,up_axis,-1);
               b2v.visual_shape_uids.push_back(shape_id);
@@ -201,11 +201,11 @@ struct OpenGLUrdfVisualizer {
               b2v.shape_colors.push_back(color);
               break;
           }
-          case TINY_BOX_TYPE:
+          case ::tds::TINY_BOX_TYPE:
           {
-              float half_extentsx = 0.5*v.geometry.box.extents[0];
-              float half_extents_y = 0.5*v.geometry.box.extents[1];
-              float half_extents_z = 0.5*v.geometry.box.extents[2];
+              float half_extentsx = 0.5*Algebra::to_double(v.geometry.box.extents[0]);
+              float half_extents_y = 0.5*Algebra::to_double(v.geometry.box.extents[1]);
+              float half_extents_z = 0.5*Algebra::to_double(v.geometry.box.extents[2]);
               int shape_id = m_opengl_app.register_cube_shape(half_extentsx,half_extents_y,half_extents_z);
               b2v.visual_shape_uids.push_back(shape_id);
               ::TINY::TinyVector3f color(1,1,1);

--- a/src/dynamics/forward_dynamics.hpp
+++ b/src/dynamics/forward_dynamics.hpp
@@ -27,7 +27,7 @@ void forward_dynamics(MultiBody<Algebra> &mb,
   typedef tds::RigidBodyInertia<Algebra> RigidBodyInertia;
   typedef tds::ArticulatedBodyInertia<Algebra> ArticulatedBodyInertia;
 
-  assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+  assert(Algebra::size(q) == mb.dof());
   assert(Algebra::size(qd) == mb.dof_qd());
   assert(Algebra::size(qdd) == mb.dof_qd());
   assert(Algebra::size(tau) == mb.dof_actuated());

--- a/src/dynamics/integrator.hpp
+++ b/src/dynamics/integrator.hpp
@@ -14,7 +14,7 @@ void integrate_euler(MultiBody<Algebra> &mb, typename Algebra::VectorX &q,
   using Vector3 = typename Algebra::Vector3;
   using Quaternion = typename Algebra::Quaternion;
 
-  assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+  assert(Algebra::size(q) == mb.dof());
   assert(Algebra::size(qd) == mb.dof_qd());
   assert(Algebra::size(qdd) == mb.dof_qd());
 
@@ -112,7 +112,8 @@ void integrate_euler_qdd(MultiBody<Algebra>& mb, typename Algebra::VectorX& q,
     using Vector3 = typename Algebra::Vector3;
     using Quaternion = typename Algebra::Quaternion;
 
-    assert(Algebra::size(q) == mb.dof());
+    assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+    
     assert(Algebra::size(qd) == mb.dof_qd());
     assert(Algebra::size(qdd) == mb.dof_qd());
 

--- a/src/dynamics/integrator.hpp
+++ b/src/dynamics/integrator.hpp
@@ -112,7 +112,7 @@ void integrate_euler_qdd(MultiBody<Algebra>& mb, typename Algebra::VectorX& q,
     using Vector3 = typename Algebra::Vector3;
     using Quaternion = typename Algebra::Quaternion;
 
-    assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+    assert(Algebra::size(q)  == mb.dof());
     
     assert(Algebra::size(qd) == mb.dof_qd());
     assert(Algebra::size(qdd) == mb.dof_qd());

--- a/src/dynamics/jacobian.hpp
+++ b/src/dynamics/jacobian.hpp
@@ -23,7 +23,7 @@ typename Algebra::Matrix3X point_jacobian(
   typedef tds::Link<Algebra> Link;
 
 
-  assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+  assert(Algebra::size(q)  == mb.dof());
   assert(link_index < static_cast<int>(mb.num_links()));
   Matrix3X jac( 3, mb.dof_qd());
   Algebra::set_zero(jac);

--- a/src/dynamics/kinematics.hpp
+++ b/src/dynamics/kinematics.hpp
@@ -28,7 +28,7 @@ void forward_kinematics(
   typedef tds::ForceVector<Algebra> ForceVector;
   typedef tds::Link<Algebra> Link;
 
-  assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+  assert(Algebra::size(q)  == mb.dof());
   assert(Algebra::size(qd) == 0 || Algebra::size(qd) == mb.dof_qd());
   assert(Algebra::size(qdd) == 0 || Algebra::size(qdd) == mb.dof_qd());
 
@@ -168,7 +168,7 @@ void forward_kinematics_q(
   typedef tds::ForceVector<Algebra> ForceVector;
   typedef tds::Link<Algebra> Link;
 
-  assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+  assert(Algebra::size(q)  == mb.dof());
   assert(base_X_world != nullptr);
 
   if (mb.is_floating()) {

--- a/src/dynamics/mass_matrix.hpp
+++ b/src/dynamics/mass_matrix.hpp
@@ -26,7 +26,7 @@ void mass_matrix(MultiBody<Algebra> &mb, const typename Algebra::VectorX &q,
   typedef tds::RigidBodyInertia<Algebra> RigidBodyInertia;
   typedef tds::ArticulatedBodyInertia<Algebra> ArticulatedBodyInertia;
 
-  assert(Algebra::size(q) - mb.spherical_joints() == mb.dof());
+  assert(Algebra::size(q) == mb.dof());
   assert(M != nullptr);
   int n = static_cast<int>(mb.num_links());
   // printf("n is %i\n", n);

--- a/src/multi_body.hpp
+++ b/src/multi_body.hpp
@@ -37,12 +37,7 @@ class MultiBody {
    */
   int dof_{0};
 
-  /**
-   * A container to store the nr of spherical joints to account for the discrepancy between the size of the coordinate
-   * vector and the nr of DoF
-   */
-  int spherical_joints_{0};
-
+  
   /**
    * Whether this system is floating or fixed to the world frame.
    */
@@ -139,11 +134,7 @@ public:
   }
   TINY_INLINE bool empty() const { return links_.empty(); }
 
-  /**
-   * Return the number of spherical joints in the system (to account for the difference between DoF and length of q_
-   */
-  TINY_INLINE int spherical_joints() const {return spherical_joints_;}
-
+  
   /**
    * Dimensionality of joint positions q (including 7-DoF floating-base
    * coordinates if this system is floating-base).
@@ -305,7 +296,7 @@ public:
     int q_index = is_floating_ ? 7 : 0;
     int qd_index = is_floating_ ? 6 : 0;
     dof_ = 0;  // excludes floating-base DOF
-    spherical_joints_ = 0;
+    
     for (Link &link : links_) {
       assert(link.index >= 0);
       link.q_index = q_index;
@@ -313,8 +304,8 @@ public:
       if (link.joint_type == JOINT_SPHERICAL) {
           q_index += 4;
           qd_index += 3;
-          dof_ += 3;
-          ++spherical_joints_;
+          dof_ += 4;
+    
       } else if(link.joint_type != JOINT_FIXED) {
         ++q_index;
         ++qd_index;
@@ -581,8 +572,8 @@ public:
       // assert(Algebra::norm(link.S) > Algebra::zero());
       link.q_index = dof();
       link.qd_index = dof_qd();
-      dof_ += 3;
-      ++spherical_joints_;
+      dof_ += 4;
+      
       // not sure about this:
       if (is_controllable) {
         if (control_indices_.empty()) {

--- a/src/visualizer/opengl/tiny_opengl3_app.cpp
+++ b/src/visualizer/opengl/tiny_opengl3_app.cpp
@@ -906,6 +906,97 @@ int TinyOpenGL3App::register_graphics_unit_sphere_shape(
   return graphicsShapeIndex;
 }
 
+
+int TinyOpenGL3App::register_graphics_capsule_shape(float radius, float half_height, int up_axis, int textureId) {
+    int red = 0;
+    int green = 255;
+    int blue = 0;  // 0;// 128;
+    if(textureId < 0) {
+        if(m_data->m_textureId < 0) {
+            int texWidth = 1024;
+            int texHeight = 1024;
+            std::vector<unsigned char> texels;
+            texels.resize(texWidth * texHeight * 3);
+            for(int i = 0; i < texWidth * texHeight * 3; i++) texels[i] = 255;
+
+            for(int i = 0; i < texWidth; i++) {
+                for(int j = 0; j < texHeight; j++) {
+                    int a = i < texWidth / 2 ? 1 : 0;
+                    int b = j < texWidth / 2 ? 1 : 0;
+
+                    if(a == b) {
+                        texels[(i + j * texWidth) * 3 + 0] = red;
+                        texels[(i + j * texWidth) * 3 + 1] = green;
+                        texels[(i + j * texWidth) * 3 + 2] = blue;
+                    }
+                    /*else
+                    {
+                    texels[i*3+0+j*texWidth] = 255;
+                    texels[i*3+1+j*texWidth] = 255;
+                    texels[i*3+2+j*texWidth] = 255;
+                    }
+                    */
+                }
+            }
+
+            m_data->m_textureId = m_instancingRenderer->register_texture(
+                &texels[0],texWidth,texHeight);
+        }
+        textureId = m_data->m_textureId;
+    }
+
+    int strideInBytes = 9 * sizeof(float);
+
+    int graphicsShapeIndex = -1;
+
+    
+    
+    int numVertices =
+        sizeof(textured_detailed_sphere_vertices) / strideInBytes;
+    int numIndices = sizeof(textured_detailed_sphere_indices) / sizeof(int);
+    //scale and transform
+
+    std::vector<float> transformedVertices;
+
+    {
+        
+        int numVertices = sizeof(textured_detailed_sphere_vertices) / strideInBytes;
+        transformedVertices.resize(numVertices * 9);
+        for(int i = 0; i < numVertices; i++)
+        {
+            TinyVector3f vert;
+            vert.setValue(textured_detailed_sphere_vertices[i * 9 + 0],
+                textured_detailed_sphere_vertices[i * 9 + 1],
+                textured_detailed_sphere_vertices[i * 9 + 2]);
+
+            TinyVector3f trVer = (2 *radius * vert);
+            if(trVer[up_axis] > 0)
+                trVer[up_axis] += half_height;
+            else
+                trVer[up_axis] -= half_height;
+
+            transformedVertices[i * 9 + 0] = trVer[0];
+            transformedVertices[i * 9 + 1] = trVer[1];
+            transformedVertices[i * 9 + 2] = trVer[2];
+            transformedVertices[i * 9 + 3] = textured_detailed_sphere_vertices[i * 9 + 3];
+            transformedVertices[i * 9 + 4] = textured_detailed_sphere_vertices[i * 9 + 4];
+            transformedVertices[i * 9 + 5] = textured_detailed_sphere_vertices[i * 9 + 5];
+            transformedVertices[i * 9 + 6] = textured_detailed_sphere_vertices[i * 9 + 6];
+            transformedVertices[i * 9 + 7] = textured_detailed_sphere_vertices[i * 9 + 7];
+            transformedVertices[i * 9 + 8] = textured_detailed_sphere_vertices[i * 9 + 8];
+        }
+    }
+
+
+    graphicsShapeIndex = m_instancingRenderer->register_shape(
+        &transformedVertices[0],numVertices,
+        textured_detailed_sphere_indices,numIndices,B3_GL_TRIANGLES,
+        textureId);
+    
+    return graphicsShapeIndex;
+}
+
+
 void TinyOpenGL3App::draw_grid(DrawGridData data) {
   int gridSize = data.gridSize;
   float upOffset = data.upOffset;

--- a/src/visualizer/opengl/tiny_opengl3_app.h
+++ b/src/visualizer/opengl/tiny_opengl3_app.h
@@ -42,6 +42,9 @@ struct TinyOpenGL3App : public TinyCommonGraphicsApp {
                                   float textureScaling = 1);
   virtual int register_graphics_unit_sphere_shape(EnumSphereLevelOfDetail lod,
                                                   int textureId = -1);
+
+  virtual int register_graphics_capsule_shape(float radius,float half_height,int up_axis,int textureId);
+
   virtual void register_grid(int xres, int yres, const ::TINY::TinyVector3f& color0,
                              const ::TINY::TinyVector3f& color1);
   void dump_next_frame_to_png(const char* pngFilename);


### PR DESCRIPTION
…_TYPE and TINY_CAPSULE_TYPE

remove multibody.spherical_joints, they should be part of dof() (adding 4 dofs, fixed joint adds 0 dof, revolute/prismatic add 1 dof), note that qdof will add 3 dofs.