### PR TITLE
Spherical joint fix

### DIFF
--- a/examples/spherical_joint_test.cpp
+++ b/examples/spherical_joint_test.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[]) {
   int num_multibodies = 1;
 
 
-  bool add_plane = false;
+  bool add_plane = true;
   if(add_plane)
   {
       MultiBody* planemb = world.create_multi_body();

--- a/src/dynamics/jacobian.hpp
+++ b/src/dynamics/jacobian.hpp
@@ -16,6 +16,7 @@ typename Algebra::Matrix3X point_jacobian(
   using Scalar = typename Algebra::Scalar;
   using Vector3 = typename Algebra::Vector3;
   using Matrix3 = typename Algebra::Matrix3;
+  using Matrix6x3 = typename Algebra::Matrix6x3;
   using Matrix3X = typename Algebra::Matrix3X;
   typedef tds::Transform<Algebra> Transform;
   typedef tds::MotionVector<Algebra> MotionVector;
@@ -62,7 +63,12 @@ typename Algebra::Matrix3X point_jacobian(
     const Link *body = &mb[link_index];
     while (true) {
       int i = body->index;
-      if (body->joint_type != JOINT_FIXED) {
+      if (body->joint_type == JOINT_SPHERICAL){
+        Matrix6x3 st = is_local_point ? links_X_base[i].apply_inverse(body->S_3d, false) : links_X_world[i].apply_inverse(body->S_3d, false);
+        Matrix6x3 xs = point_tf.apply(st, false);
+        Algebra::assign_block(jac, Algebra::bottom(xs), 0, body->qd_index);
+      }
+      else if (body->joint_type != JOINT_FIXED) {
         MotionVector st = is_local_point ? links_X_base[i].apply_inverse(body->S) : links_X_world[i].apply_inverse(body->S);
         MotionVector xs = point_tf.apply(st);
         Algebra::assign_column(jac, body->qd_index, xs.bottom);

--- a/src/dynamics/mass_matrix.hpp
+++ b/src/dynamics/mass_matrix.hpp
@@ -61,7 +61,7 @@ void mass_matrix(MultiBody<Algebra> &mb, const typename Algebra::VectorX &q,
 
       int j = i;
       while (mb[j].parent_index != -1) {
-        Fi = mb[j].X_parent.apply(Fi);
+        Fi = mb[j].X_parent.apply(Fi, true);
         j = mb[j].parent_index;
         if (mb[j].joint_type == JOINT_FIXED) continue;
         int qd_j = mb[j].qd_index;
@@ -79,7 +79,7 @@ void mass_matrix(MultiBody<Algebra> &mb, const typename Algebra::VectorX &q,
         }
       }
       if (mb.is_floating()) {
-        Fi = mb[j].X_parent.apply(Fi);
+        Fi = mb[j].X_parent.apply(Fi, true);
         Algebra::assign_block(*M, Fi, 0, qd_i, 6, 3);
         Algebra::assign_block(*M, Algebra::transpose(Fi), qd_i, 0, 6, 3);
       }


### PR DESCRIPTION
I fixed the collision issue for spherical joints by adding a case to the jacobian calculation. I had to create 'apply' and 'apply_inverse' methods for 3x6 (Force/Motion matrices) in the transform class. 
These are different for Force and Motion matrices so I implemented them using a flag indicating what they are. Is this an issue regarding differentiability?