### PR TITLE
Update Python examples to use new datatype names

### DIFF
--- a/python/examples/b_urdf_structs_example.py
+++ b/python/examples/b_urdf_structs_example.py
@@ -23,7 +23,7 @@ def create_multi_body(mass, collision_shapes, is_floating, world):
   base_link.link_name = "plane_link"
   inertial = pd.TinyUrdfInertial()
   inertial.mass = mass 
-  inertial.inertia_xxyyzz = pd.TinyVector3(mass,mass,mass)
+  inertial.inertia_xxyyzz = pd.Vector3(mass,mass,mass)
   base_link.urdf_inertial = inertial
   
   base_link.urdf_collision_shapes = collision_shapes
@@ -37,21 +37,21 @@ world = pd.TinyWorld()
 collision_shape = pd.TinyUrdfCollision()
 
 collision_shape.geometry.geom_type = pd.PLANE_TYPE
-collision_shape.origin_xyz = pd.TinyVector3(0.,0.,2.)
+collision_shape.origin_xyz = pd.Vector3(0.,0.,2.)
 plane_mb = create_multi_body(0, [collision_shape], False, world)
 
 collision_shape = pd.TinyUrdfCollision()
 collision_shape.geometry.geom_type = pd.SPHERE_TYPE
 collision_shape.geometry.sphere.radius = 2.0
 sphere_mb = create_multi_body(2.0, [collision_shape], True, world)
-sphere_mb.set_base_position(pd.TinyVector3(0.,0.,25.))
+sphere_mb.set_base_position(pd.Vector3(0.,0.,25.))
 dt = 1./240.
 
 mb_solver = pd.TinyMultiBodyConstraintSolver()
 
 while 1:
     
-  pd.forward_dynamics(sphere_mb, pd.TinyVector3(0., 0., -10.))
+  pd.forward_dynamics(sphere_mb, pd.Vector3(0., 0., -10.))
   
   #collision detection
   multi_bodies = [plane_mb, sphere_mb]

--- a/python/examples/billiard_optimization.py
+++ b/python/examples/billiard_optimization.py
@@ -27,7 +27,7 @@ def rollout(force_x, force_y, step, render):
   dt = dp.fraction(1, 60)
   gravity_z = dp.fraction(0,1)
   world = dp.TinyWorld()
-  world.gravity = dp.TinyVector3(dp.fraction(0,1),dp.fraction(0,1),dp.fraction(0,1))
+  world.gravity = dp.Vector3(dp.fraction(0,1),dp.fraction(0,1),dp.fraction(0,1))
     
   radius = dp.fraction(1,2)
   mass = dp.fraction(1,1)
@@ -38,7 +38,7 @@ def rollout(force_x, force_y, step, render):
   rx = dp.fraction(0,1)
   y = dp.fraction(0,1)
   
-  target_pos = dp.TinyVector3(dp.fraction(35, 10),dp.fraction(8, 1), dp.fraction(0,1))
+  target_pos = dp.Vector3(dp.fraction(35, 10),dp.fraction(8, 1), dp.fraction(0,1))
   ball_id = 0
   target_id = 5
   
@@ -61,7 +61,7 @@ def rollout(force_x, force_y, step, render):
       geom = dp.TinySphere(radius)
       geoms.append(geom)
       body = dp.TinyRigidBody(mass, geom)
-      body.world_pose.position = dp.TinyVector3(x, y, dp.fraction(0,1))
+      body.world_pose.position = dp.Vector3(x, y, dp.fraction(0,1))
       bodies.append(body)
       
       if render:
@@ -87,12 +87,12 @@ def rollout(force_x, force_y, step, render):
     y = y + dy
   
   #white player ball
-  white = dp.TinyVector3(dp.fraction(0,1), -dp.fraction(2,1), dp.fraction(0,1))
+  white = dp.Vector3(dp.fraction(0,1), -dp.fraction(2,1), dp.fraction(0,1))
   white_geom = dp.TinySphere(radius);
   white_ball = dp.TinyRigidBody(mass, white_geom)
   white_ball.world_pose.position = white
   bodies.append(white_ball)
-  white_ball.apply_central_force(dp.TinyVector3(force_x, force_y, dp.fraction(0,1)))
+  white_ball.apply_central_force(dp.Vector3(force_x, force_y, dp.fraction(0,1)))
 
   if render:
     orn = p.TinyQuaternionf(0.,0.,0.,1.)

--- a/python/examples/c_urdf_structs_mesh_cat_example.py
+++ b/python/examples/c_urdf_structs_mesh_cat_example.py
@@ -29,7 +29,7 @@ def create_multi_body(link_name, mass, collision_shapes, visual_shapes, is_float
   base_link.link_name = link_name
   inertial = pd.TinyUrdfInertial()
   inertial.mass = mass 
-  inertial.inertia_xxyyzz = pd.TinyVector3(mass,mass,mass)
+  inertial.inertia_xxyyzz = pd.Vector3(mass,mass,mass)
   base_link.urdf_inertial = inertial
   
   base_link.urdf_collision_shapes = collision_shapes
@@ -53,7 +53,7 @@ world = pd.TinyWorld()
 
 collision_shape = pd.TinyUrdfCollision()
 collision_shape.geometry.geom_type = pd.PLANE_TYPE
-collision_shape.origin_xyz = pd.TinyVector3(0.,0.,2.)
+collision_shape.origin_xyz = pd.Vector3(0.,0.,2.)
 plane_mb, _ = create_multi_body("plane_link", 0, [collision_shape], [], False, vis, world)
 
 
@@ -68,7 +68,7 @@ collision_shape = pd.TinyUrdfCollision()
 collision_shape.geometry.geom_type = pd.SPHERE_TYPE
 collision_shape.geometry.sphere.radius = sphere_radius
 sphere_mb, sphere2vis = create_multi_body("sphere_link", 2.0, [collision_shape], [visual_shape], True, vis, world)
-sphere_mb.set_base_position(pd.TinyVector3(0.,0.,25.))
+sphere_mb.set_base_position(pd.Vector3(0.,0.,25.))
 dt = 1./240.
 
 mb_solver = pd.TinyMultiBodyConstraintSolver()
@@ -80,7 +80,7 @@ mb_solver = pd.TinyMultiBodyConstraintSolver()
           
 while 1:
   
-  pd.forward_dynamics(sphere_mb, pd.TinyVector3(0.,0.,-10.))
+  pd.forward_dynamics(sphere_mb, pd.Vector3(0.,0.,-10.))
   #pd.integrate_q(sphere_mb, dt)
   
    #collision detection

--- a/python/examples/d_meshcat_tinymultibody.py
+++ b/python/examples/d_meshcat_tinymultibody.py
@@ -87,14 +87,14 @@ is_floating = True
 laikago_mb = dp.TinyMultiBody(is_floating)
 
 res = urdf2mb.convert2(med0.urdf_structs, world, laikago_mb)
-laikago_mb.set_base_position(dp.TinyVector3(3., 2., 0.7))
-laikago_mb.set_base_orientation(dp.TinyQuaternion(0.8042817254804792, 0.08692563458095628, -0.12155529396079404, 0.5751514153863713))#0.2474039592545229, 0.0, 0.0, 0.9689124217106448))
+laikago_mb.set_base_position(dp.Vector3(3., 2., 0.7))
+laikago_mb.set_base_orientation(dp.Quaternion(0.8042817254804792, 0.08692563458095628, -0.12155529396079404, 0.5751514153863713))#0.2474039592545229, 0.0, 0.0, 0.9689124217106448))
 mb_solver = dp.TinyMultiBodyConstraintSolver()
 
-q = dp.TinyVectorX(2)
+q = dp.VectorX(2)
 q[0] = -0.53167
 q[1] = 0.30707
-qd = dp.TinyVectorX(2)
+qd = dp.VectorX(2)
 qd[0] = -1
 qd[1] = 0
 
@@ -111,8 +111,8 @@ dt = 1. / 1000.
 
 while p0.isConnected():
   #dp.forward_kinematics(laikago_mb, laikago_mb.q, laikago_mb.qd)
-  dp.forward_dynamics(laikago_mb, dp.TinyVector3(0., 0., -10.))
-  #dp.forward_dynamics(laikago_mb, dp.TinyVector3(0., 0., 0.))
+  dp.forward_dynamics(laikago_mb, dp.Vector3(0., 0., -10.))
+  #dp.forward_dynamics(laikago_mb, dp.Vector3(0., 0., 0.))
   
   if 1:
     multi_bodies = [plane_mb, laikago_mb]

--- a/python/examples/f_meshcat_tinyurdf.py
+++ b/python/examples/f_meshcat_tinyurdf.py
@@ -208,9 +208,9 @@ is_floating=True
 mb = dp.TinyMultiBody(is_floating)
 urdf2mb = dp.UrdfToMultiBody2()
 res = urdf2mb.convert2(urdf_data, world, mb)
-mb.set_base_position(dp.TinyVector3(0,0,0.6))
+mb.set_base_position(dp.Vector3(0,0,0.6))
 
-mb.set_base_orientation(dp.TinyQuaternion(0.0, 0.0, 0.706825181105366, 0.7073882691671998))
+mb.set_base_orientation(dp.Quaternion(0.0, 0.0, 0.706825181105366, 0.7073882691671998))
 
 knee_angle = -0.5
 abduction_angle = 0.2
@@ -234,7 +234,7 @@ frame = 0
 while 1:
   dp.forward_kinematics(mb, mb.q, mb.qd)
   
-  dp.forward_dynamics(mb, dp.TinyVector3(0.,0.,-10.))
+  dp.forward_dynamics(mb, dp.Vector3(0.,0.,-10.))
 
   
   mb_q = vecx_to_np(mb.q)[7:]

--- a/python/examples/g_raycast.py
+++ b/python/examples/g_raycast.py
@@ -37,8 +37,8 @@ colliders = plane_urdf_data.base_links[0].urdf_collision_shapes
 print("num_colliders=",len(colliders))
 ray_from=[]
 ray_to=[]
-ray_from.append(dp.TinyVector3(-2,.1,0))
-ray_to.append(dp.TinyVector3(2,.1,0))
+ray_from.append(dp.Vector3(-2,.1,0))
+ray_to.append(dp.Vector3(2,.1,0))
 caster = dp.TinyRaycast()
 
 colliders = []
@@ -56,11 +56,11 @@ if 1:
 if 1:
     collision_shape = dp.TinyUrdfCollision()
     collision_shape.geometry.geom_type = dp.BOX_TYPE
-    collision_shape.geometry.box.extents = dp.TinyVector3(1,0.1,0.1)
+    collision_shape.geometry.box.extents = dp.Vector3(1,0.1,0.1)
     colliders.append(collision_shape)
     collision_shape = dp.TinyUrdfCollision()
     collision_shape.geometry.geom_type = dp.BOX_TYPE
-    collision_shape.geometry.box.extents = dp.TinyVector3(1.5,0.15,0.15)
+    collision_shape.geometry.box.extents = dp.Vector3(1.5,0.15,0.15)
     colliders.append(collision_shape)
 
 

--- a/python/examples/meshcat_utils_dp.py
+++ b/python/examples/meshcat_utils_dp.py
@@ -109,11 +109,11 @@ def sync_visual_transforms(mb, b2vis, vis):
     link_world_trans = mb.get_world_transform(v.link_index)
 
     vpos = v.origin_xyz
-    vorn = dp.TinyQuaternion(0.0, 0.0, 0.0, 1.0)
+    vorn = dp.Quaternion(0.0, 0.0, 0.0, 1.0)
     vorn.set_euler_rpy(v.origin_rpy)
     trv = dp.TinySpatialTransform()
     trv.translation = vpos
-    trv.rotation = dp.TinyMatrix3x3(vorn)
+    trv.rotation = dp.Matrix3(vorn)
     #print("link_world_trans.x=",link_world_trans.translation.x)
     #print("link_world_trans.y=",link_world_trans.translation.y)
     #print("link_world_trans.z=",link_world_trans.translation.z)

--- a/python/examples/urdf_utils_pb.py
+++ b/python/examples/urdf_utils_pb.py
@@ -31,7 +31,7 @@ class UrdfConverterPyBullet(ued.UrdfEditor):
     super(ued.UrdfEditor, self).__init__(**kwargs)
 
   def convert_vec(self, vec):
-    vec = dp.TinyVector3(vec[0], vec[1], vec[2])
+    vec = dp.Vector3(vec[0], vec[1], vec[2])
     return vec
 
   def convert_geom_type(self, geom_type):

--- a/python/examples/whole_body_control/laikago_tds_sim_clean.py
+++ b/python/examples/whole_body_control/laikago_tds_sim_clean.py
@@ -271,7 +271,7 @@ class SimpleRobot(object):
     self.mb = dp.TinyMultiBody(is_floating)
     urdf2mb = dp.UrdfToMultiBody2()
     self.res = urdf2mb.convert2(self.urdf_data, self.world, self.mb)
-    self.mb.set_base_position(dp.TinyVector3(0,0,0.6))
+    self.mb.set_base_position(dp.Vector3(0,0,0.6))
 
     knee_angle = -0.5
     abduction_angle = 0.2
@@ -312,8 +312,8 @@ class SimpleRobot(object):
     self._motor_model = LaikagoMotorModel(kp=self._kp, kd=self._kd, motor_control_mode=MOTOR_CONTROL_HYBRID)
     
     self.ReceiveObservation()
-    self.mb.set_base_position(dp.TinyVector3(START_POS[0],START_POS[1],START_POS[2]))
-    self.mb.set_base_orientation(dp.TinyQuaternion(START_ORN[0],START_ORN[1],START_ORN[2],START_ORN[3]))
+    self.mb.set_base_position(dp.Vector3(START_POS[0],START_POS[1],START_POS[2]))
+    self.mb.set_base_orientation(dp.Quaternion(START_ORN[0],START_ORN[1],START_ORN[2],START_ORN[3]))
     
     dp.forward_kinematics(self.mb, self.mb.q, self.mb.qd)
     meshcat_utils_dp.sync_visual_transforms(self.mb, self.b2vis, self.vis)
@@ -445,12 +445,12 @@ class SimpleRobot(object):
       #tds
       base_world_tr = self.mb.get_world_transform(-1)
       local_base_tr = dp.TinySpatialTransform()
-      local_base_tr.translation = dp.TinyVector3(base_translation[0],base_translation[1],base_translation[2])
-      local_base_tr.rotation.setRotation(dp.TinyQuaternion(base_rotation[0],base_rotation[1],base_rotation[2],base_rotation[3]))
+      local_base_tr.translation = dp.Vector3(base_translation[0],base_translation[1],base_translation[2])
+      local_base_tr.rotation.setRotation(dp.Quaternion(base_rotation[0],base_rotation[1],base_rotation[2],base_rotation[3]))
       world_tr = base_world_tr*local_base_tr
       local_link_tr = dp.TinySpatialTransform()
       local_link_tr.rotation.set_identity()
-      local_link_tr.translation = dp.TinyVector3(link_position[0],link_position[1],link_position[2])
+      local_link_tr.translation = dp.Vector3(link_position[0],link_position[1],link_position[2])
       link_tr = world_tr* local_link_tr
       world_link_pos = [link_tr.translation[0],link_tr.translation[1],link_tr.translation[2]]
         
@@ -459,7 +459,7 @@ class SimpleRobot(object):
 
     ik_solver = 0
     
-    target_world_pos = dp.TinyVector3(world_link_pos[0],world_link_pos[1],world_link_pos[2])
+    target_world_pos = dp.Vector3(world_link_pos[0],world_link_pos[1],world_link_pos[2])
     #target_local_pos = self.mb.get_world_transform(-1).apply_inverse(target_world_pos)
     
     all_joint_angles2 = dp.inverse_kinematics(self.mb, link_id, target_world_pos)
@@ -558,12 +558,12 @@ class SimpleRobot(object):
     # orientation given by dividing (or multiplying with inverse).
     # Get inverse quaternion assuming the vector is at 0,0,0 origin.
     tr = dp.TinySpatialTransform()
-    tr.translation = dp.TinyVector3(1,2,3)
+    tr.translation = dp.Vector3(1,2,3)
     tr.translation.set_zero()
-    orn = dp.TinyQuaternion(orientation[0],orientation[1],orientation[2],orientation[3])
+    orn = dp.Quaternion(orientation[0],orientation[1],orientation[2],orientation[3])
     tr.rotation.setRotation(orn)
     tr_inv = tr.get_inverse()
-    rel_vel = tr.apply_inverse(dp.TinyVector3(angular_velocity[0],angular_velocity[1],angular_velocity[2]))
+    rel_vel = tr.apply_inverse(dp.Vector3(angular_velocity[0],angular_velocity[1],angular_velocity[2]))
     #tr.print("tds trans")
     #print("tds rel_vel=",rel_vel)
     
@@ -657,7 +657,7 @@ class SimpleRobot(object):
     """
     
     dp.forward_kinematics(self.mb, self.mb.q, self.mb.qd)
-    dp.forward_dynamics(self.mb, dp.TinyVector3(0.,0.,-10.))
+    dp.forward_dynamics(self.mb, dp.Vector3(0.,0.,-10.))
 
     mb_q = vecx_to_np(self.mb.q)[7:]
     mb_qd = vecx_to_np(self.mb.qd)[6:]

--- a/python/pytinydiffsim.inl
+++ b/python/pytinydiffsim.inl
@@ -112,6 +112,9 @@
       .def("get_euler_rpy2", [](const Quaternion &q) {
           return MyAlgebra::get_euler_rpy2(q);
       })
+      .def("set_euler_rpy", [](Quaternion &q, const Vector3 &rpy) {
+          MyAlgebra::set_euler_rpy(q, rpy);
+      })
       .def("normalized", [](const Quaternion &q) {
           Quaternion q2(q);
           MyAlgebra::normalize(q2);

--- a/python/pytinydiffsim_example.py
+++ b/python/pytinydiffsim_example.py
@@ -25,7 +25,7 @@ Will also expose stan_math forward mode differentiation, dual and fixed point.
 from absl import app
 from absl import flags
 
-import pytinydiffsim2 as pydiffphys
+import pytinydiffsim as pydiffphys
 
 FLAGS = flags.FLAGS
 
@@ -50,7 +50,7 @@ def main(argv):
 
   w = pydiffphys.TinyWorld()
 
-  w.gravity = pydiffphys.TinyVector3(0, 0, -9.81)
+  w.gravity = pydiffphys.Vector3(0, 0, -9.81)
   g = w.gravity
   print("g=", g.z)
   plane = pydiffphys.TinyPlane()
@@ -62,10 +62,10 @@ def main(argv):
   b2 = pydiffphys.TinyRigidBody(mass, sphere)
 
   print("b.linear_velocity=", b1.linear_velocity)
-  pos_a = pydiffphys.TinyVector3(0, 0, 0)
-  orn_a = pydiffphys.TinyQuaternion(0, 0, 0, 1)
-  pos_b = pydiffphys.TinyVector3(0, 0, 50)
-  orn_b = pydiffphys.TinyQuaternion(0, 0, 0, 1)
+  pos_a = pydiffphys.Vector3(0, 0, 0)
+  orn_a = pydiffphys.Quaternion(0, 0, 0, 1)
+  pos_b = pydiffphys.Vector3(0, 0, 50)
+  orn_b = pydiffphys.Quaternion(0, 0, 0, 1)
 
   pose_a = pydiffphys.TinyPose(pos_a, orn_a)
   pose_b = pydiffphys.TinyPose(pos_b, orn_b)

--- a/src/math/eigen_algebra.hpp
+++ b/src/math/eigen_algebra.hpp
@@ -820,20 +820,8 @@ struct EigenAlgebraT {
    * @param pitch Angle around Y
    * @param roll Angle around X */
   EIGEN_ALWAYS_INLINE static const Quaternion quat_from_euler_rpy(const Vector3& rpy) {
-    Scalar phi, the, psi;
-    Scalar roll = rpy[0];
-    Scalar pitch = rpy[1];
-    Scalar yaw = rpy[2];
-    phi = roll * Scalar(0.5);
-    the = pitch * Scalar(0.5);
-    psi = yaw * Scalar(0.5);
-
-    Quaternion q = quat_from_xyzw(
-                 sin(phi) * cos(the) * cos(psi) - cos(phi) * sin(the) * sin(psi), // x
-                 cos(phi) * sin(the) * cos(psi) + sin(phi) * cos(the) * sin(psi), // y
-                 cos(phi) * cos(the) * sin(psi) - sin(phi) * sin(the) * cos(psi), // z
-                 cos(phi) * cos(the) * cos(psi) + sin(phi) * sin(the) * sin(psi)); // w
-    normalize(q);
+    Quaternion q;
+    set_euler_rpy(q, rpy);
     return q;
   }
   
@@ -936,6 +924,22 @@ struct EigenAlgebraT {
     rpy[2] = -atan2(s1 * m20 - c1 * m10, c1 * m11 - s1 * m21);
 
     return rpy;
+  }
+  
+  EIGEN_ALWAYS_INLINE static void set_euler_rpy(Quaternion &q, const Vector3& rpy) {
+    Scalar phi, the, psi;
+    Scalar roll = rpy[0];
+    Scalar pitch = rpy[1];
+    Scalar yaw = rpy[2];
+    phi = roll * half();
+    the = pitch * half();
+    psi = yaw * half();
+
+    q.x() = sin(phi) * cos(the) * cos(psi) - cos(phi) * sin(the) * sin(psi);
+    q.y() = cos(phi) * sin(the) * cos(psi) + sin(phi) * cos(the) * sin(psi);
+    q.z() = cos(phi) * cos(the) * sin(psi) - sin(phi) * sin(the) * cos(psi);
+    q.w() = cos(phi) * cos(the) * cos(psi) + sin(phi) * sin(the) * sin(psi);
+    normalize(q);
   }
 
   EIGEN_ALWAYS_INLINE static void set_zero(Matrix3 &m) { m.setZero(); }

--- a/src/math/tiny/tiny_algebra.hpp
+++ b/src/math/tiny/tiny_algebra.hpp
@@ -601,19 +601,8 @@ struct TinyAlgebra {
    * @param pitch Angle around Y
    * @param roll Angle around X */
   TINY_INLINE static const Quaternion quat_from_euler_rpy(const Vector3& rpy) {
-    Scalar phi, the, psi;
-    Scalar roll = rpy[0];
-    Scalar pitch = rpy[1];
-    Scalar yaw = rpy[2];
-    phi = roll * half();
-    the = pitch * half();
-    psi = yaw * half();
-    Quaternion q = quat_from_xyzw(
-                 sin(phi) * cos(the) * cos(psi) - cos(phi) * sin(the) * sin(psi), // x
-                 cos(phi) * sin(the) * cos(psi) + sin(phi) * cos(the) * sin(psi), // y
-                 cos(phi) * cos(the) * sin(psi) - sin(phi) * sin(the) * cos(psi), // z
-                 cos(phi) * cos(the) * cos(psi) + sin(phi) * sin(the) * sin(psi)); // w
-    q.normalize();
+    Quaternion q;
+    set_euler_rpy(q, rpy);
     return q;
   }
   
@@ -623,6 +612,10 @@ struct TinyAlgebra {
   
   TINY_INLINE static const Vector3 get_euler_rpy2(const Quaternion &q) {
     return q.get_euler_rpy2();
+  }
+  
+  TINY_INLINE static void set_euler_rpy(Quaternion &q, const Vector3& rpy) {
+    q.set_euler_rpy(rpy);
   }
 
   TINY_INLINE static void set_zero(Matrix3 &m) { m.set_zero(); }


### PR DESCRIPTION
Hi!

I updated the Python examples to use for example Vector3 instead of TinyVector3.
