### PR TITLE
Add get_world_com() to Python interface

### DIFF
--- a/python/pytinydiffsim.inl
+++ b/python/pytinydiffsim.inl
@@ -521,10 +521,9 @@
           &MultiBody<MyAlgebra>::get_position)
       .def("get_base_orientation",
           &MultiBody<MyAlgebra>::get_orientation)
-
       .def("get_world_transform",
            &MultiBody<MyAlgebra>::get_world_transform)
-
+      .def("get_world_com", &MultiBody<MyAlgebra>::get_world_com)
       .def("attach_link", &MultiBody<MyAlgebra>::attach_link)
       .def("set_q", &MultiBody<MyAlgebra>::set_q)
 #if 0

--- a/src/math/tiny/cppad_utils.h
+++ b/src/math/tiny/cppad_utils.h
@@ -200,7 +200,7 @@ namespace TinyAD
   
   template <typename Scalar = double>
   inline void print_ad(const std::string& s, const CppAD::AD<Scalar>& v) {
-    CppAD::PrintFor(v, s.c_str(), v, "\n");
+    CppAD::PrintFor(CppAD::AD<Scalar>(-1), s.c_str(), v, "\n");
   }
 
 } 

--- a/src/multi_body.hpp
+++ b/src/multi_body.hpp
@@ -449,7 +449,7 @@ public:
     if (link == -1) {
       return tf.apply(base_rbi_.com);
     } else {
-      return tf.apply(links_[link].I.com);
+      return tf.apply(links_[link].rbi.com);
     }
   }
 


### PR DESCRIPTION
This PR adds `get_world_com()` together with minor changes in the CppAD Python bindings.

The first commit should solve #103.