### PR TITLE
bug fix: adding algorithm header back to geometry.hpp

### DIFF
--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -18,6 +18,7 @@
 
 #include <stdexcept>
 #include <vector>
+#include <algorithm>
 
 #include "math/pose.hpp"
 #include <cassert>


### PR DESCRIPTION
I think commit d991b174dbc68aaf7edbb276d7060ba848e23fc8 may have broken the build? It removed the headers needed for std::clamp which it was getting through sdf_utils.h -> functional -> algorithm