### PR TITLE
fix: typo grammar

### DIFF
--- a/python/examples/whole_body_control/locomotion_controller.py
+++ b/python/examples/whole_body_control/locomotion_controller.py
@@ -88,7 +88,7 @@ class LocomotionController(object):
     self._stance_leg_controller.update(self._time_since_reset)
 
   def get_action(self):
-    """Returns the control ouputs (e.g. positions/torques) for all motors."""
+    """Returns the control outputs (e.g. positions/torques) for all motors."""
     swing_action = self._swing_leg_controller.get_action()
     stance_action, qp_sol = self._stance_leg_controller.get_action()
     action = []

--- a/python/examples/whole_body_control/raibert_swing_leg_controller.py
+++ b/python/examples/whole_body_control/raibert_swing_leg_controller.py
@@ -95,7 +95,7 @@ class RaibertSwingLegController(leg_controller.LegController):
   """Controls the swing leg position using Raibert's formula.
 
   For details, please refer to chapter 2 in "Legged robbots that balance" by
-  Marc Raibert. The key idea is to stablize the swing foot's location based on
+  Marc Raibert. The key idea is to stabilize the swing foot's location based on
   the CoM moving speed.
 
   """

--- a/src/utils/filesystem.hpp
+++ b/src/utils/filesystem.hpp
@@ -50,7 +50,7 @@
 #       error Could not find system header "<filesystem>" or "<experimental/filesystem>"
 #   endif
 
-// We priously determined that we need the exprimental version
+// We priously determined that we need the experimental version
 #   if INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
 // Include it
 #       include <experimental/filesystem>

--- a/src/visualizer/opengl/tiny_fonts.cpp
+++ b/src/visualizer/opengl/tiny_fonts.cpp
@@ -143,7 +143,7 @@ CTexFont *TwGenerateFont(const unsigned char *_Bitmap, int _BmWidth,
             du = 0;
             dv = 0;
         }
-        else    // texel alignement for D3D
+        else    // texel alignment for D3D
         {
             du = 0.5f;
             dv = 0.5f;


### PR DESCRIPTION
## description
fix typo spelling grammar, replace to correct words with reference from [merriam webster](merriam-webster.com)

## testing
testing not include because just replace the typo to correct one