### PR TITLE
Normalize quaternion in rotate(q, v)

### DIFF
--- a/src/math/eigen_algebra.hpp
+++ b/src/math/eigen_algebra.hpp
@@ -877,7 +877,7 @@ struct EigenAlgebraT {
 
   EIGEN_ALWAYS_INLINE static Vector3 rotate(const Quaternion &q,
                                             const Vector3 &w) {
-    return q * w;
+    return normalize(q) * w;
 
  /* Rotating with an all zero quaternion results in
        a rotation with the identity quaternion in Eigen.


### PR DESCRIPTION
During contact computation I have noticed that the collision geometry poses sometimes are not perfectly normalized.
When we then call `rotate` we rotate a vector with an unnormalized quaternion. A quick fix would be to normalize here.

I haven't dug into this deeper into the root cause but it seems like it might happen when we go from rotation matrices to quaternions here:
https://github.com/google-research/tiny-differentiable-simulator/blob/a564170bef387522c7149bbaa843ba0125e1a900/src/world.hpp#L247