### PR TITLE
Uncomment mb_collision_geometries in Python API

### DIFF
--- a/python/pytinydiffsim.inl
+++ b/python/pytinydiffsim.inl
@@ -670,7 +670,7 @@
   m.def("link_transform_base_frame", &MyGetLinkTransformInBase);
   m.def("find_file", &MyFindFile);
   m.def("quat_difference", &QuaternionDifference);
-  //m.def("mb_collision_geometries", &mb_collision_geometries);
+  m.def("mb_collision_geometries", &mb_collision_geometries);
 
   m.def("pi", &MyPi);
   m.def("cos", &MyCos);


### PR DESCRIPTION
Hi, 

I need to access the collision geometries from the Python API. Was the function unintentionally comment it out (in 2daf3708037bb317f2badc80c4b0ff2787e0fe9f) or would you prefer another solution to accessing the geometries?

/Erik