### PR TITLE
Add mb_collision_geometries

### DIFF
--- a/python/pytinydiffsim.inl
+++ b/python/pytinydiffsim.inl
@@ -667,8 +667,7 @@
   m.def("link_transform_base_frame", &MyGetLinkTransformInBase);
   m.def("find_file", &MyFindFile);
   m.def("quat_difference", &QuaternionDifference);
-  //where is the definition of mb_collision_geometries? error when compiling cppad version
-  //m.def("mb_collision_geometries", &mb_collision_geometries);
+  m.def("mb_collision_geometries", &mb_collision_geometries);
 
   m.def("pi", &MyPi);
   m.def("cos", &MyCos);

--- a/python/pytinydiffsim_includes.h
+++ b/python/pytinydiffsim_includes.h
@@ -206,3 +206,13 @@ MyAlgebra::Quaternion QuaternionDifference(const MyAlgebra::Quaternion &q_start,
     return MyAlgebra::quat_difference(q_start, q_end);
 }
 
+const std::vector<const tds::Geometry<MyAlgebra> *>* mb_collision_geometries(
+        const tds::MultiBody<MyAlgebra>& mb, int link_id) {
+    /* Returns a cloned copies of the collision geometries */
+    const std::vector<const tds::Geometry<MyAlgebra> *> colls = mb.collision_geometries(link_id);
+    std::vector<const tds::Geometry<MyAlgebra> *> *collision_geometries = new std::vector<const tds::Geometry<MyAlgebra> *>;
+    for (const auto *geom : colls) {
+      collision_geometries->push_back(tds::clone<MyAlgebra, MyAlgebra>(geom));
+    }
+    return collision_geometries;
+}


### PR DESCRIPTION
Fix #167 to enable the function mb_collision_geometries() in Python API. 