### PR TITLE
Get rid of redundant `geoms_` in world.hpp

### DIFF
--- a/src/multi_body.hpp
+++ b/src/multi_body.hpp
@@ -91,6 +91,15 @@ class MultiBody {
 
   explicit MultiBody(bool isFloating = false) : is_floating_(isFloating) {}
 
+  virtual ~MultiBody() { clear(); }
+
+  void clear() {
+    for (auto p : collision_geometries_) {
+      delete p;
+    }
+    collision_geometries_.clear();
+  }
+
   template <typename AlgebraTo = Algebra>
   MultiBody<AlgebraTo> clone() const {
     typedef Conversion<Algebra, AlgebraTo> C;
@@ -588,7 +597,7 @@ class MultiBody {
         "JOINT_FIXED",       "JOINT_PRISMATIC_X",    "JOINT_PRISMATIC_Y",
         "JOINT_PRISMATIC_Z", "JOINT_PRISMATIC_AXIS", "JOINT_REVOLUTE_X",
         "JOINT_REVOLUTE_Y",  "JOINT_REVOLUTE_Z",     "JOINT_REVOLUTE_AXIS",
-        "JOINT_SPHERICAL", "JOINT_INVALID",
+        "JOINT_SPHERICAL",   "JOINT_INVALID",
     };
     return names[int(t) + 1];
   }

--- a/src/rigid_body.hpp
+++ b/src/rigid_body.hpp
@@ -59,6 +59,8 @@ class RigidBody {
     Algebra::set_zero(total_torque_);
   }
 
+  virtual ~RigidBody() { delete geometry_; }
+
   template <typename AlgebraTo = Algebra>
   RigidBody<AlgebraTo> clone() const {
     typedef Conversion<Algebra, AlgebraTo> C;

--- a/src/world.hpp
+++ b/src/world.hpp
@@ -48,10 +48,7 @@ class World {
   std::vector<MultiBody*> multi_bodies_;
 
   Vector3 gravity_acceleration_;
-
-  std::vector<Geometry*> geoms_;
-
-  
+ 
 
   CollisionDispatcher<Algebra> dispatcher_;
   RigidBodyConstraintSolver<Algebra>* rb_constraint_solver_{nullptr};
@@ -77,7 +74,6 @@ class World {
 
   size_t num_rigid_bodies() const { return rigid_bodies_.size(); }
   size_t num_multi_bodies() const { return multi_bodies_.size(); }
-  size_t num_geoms() const { return geoms_.size(); }
 
   inline void submit_profile_timing(const char* name=0) const {
     if (profile_timing_func_) {
@@ -99,9 +95,6 @@ class World {
   }
 
   void clear() {
-    while (!geoms_.empty()) {
-      delete geoms_.back(), geoms_.pop_back();
-    }
     while (!rigid_bodies_.empty()) {
       delete rigid_bodies_.back(), rigid_bodies_.pop_back();
     }
@@ -122,25 +115,21 @@ class World {
 
   Capsule* create_capsule(const Scalar& radius, const Scalar& length) {
     Capsule* capsule = new Capsule(radius, length);
-    geoms_.push_back(capsule);
     return capsule;
   }
 
   Plane* create_plane() {
     Plane* plane = new Plane();
-    geoms_.push_back(plane);
     return plane;
   }
 
   Sphere* create_sphere(const Scalar& radius) {
     Sphere* sphere = new Sphere(radius);
-    geoms_.push_back(sphere);
     return sphere;
   }
   
    Box* create_box (const Vector3& extents) {
       Box* box = new Box(extents);
-      geoms_.push_back(box);
       return box;
   }
 


### PR DESCRIPTION
Looks like `std::vector<Geometry*> geoms_;`  and `size_t num_geoms() const { return geoms_.size(); }` in `world.hpp` are not used anywhere.
