### PR TITLE
Capsule-sphere collides at closest point on segment.

### DIFF
--- a/src/geometry.hpp
+++ b/src/geometry.hpp
@@ -105,6 +105,7 @@ template <typename Algebra>
 class Capsule : public Geometry<Algebra> {
   using Scalar = typename Algebra::Scalar;
   using Vector3 = typename Algebra::Vector3;
+  typedef tds::Pose<Algebra> Pose;
 
   Scalar radius;
   Scalar length;
@@ -149,6 +150,16 @@ class Capsule : public Geometry<Algebra> {
                                   this->length / Scalar(2)));
     return Algebra::norm(pt) - this->radius;
   }
+
+  Pose _get_t_b_pose(const Pose &pose, double tip) const {
+    Pose offset;
+    Algebra::set_identity(offset.orientation_);
+    offset.position_ = Vector3(Algebra::zero(), Algebra::zero(),
+                               Algebra::fraction(tip, 2) * get_length());
+    return pose * offset;
+  }
+  Pose get_tip_pose(const Pose &pose) const { return _get_t_b_pose(pose, 1); }
+  Pose get_base_pose(const Pose &pose) const { return _get_t_b_pose(pose, -1); }
 };
 
 template <typename Algebra>

--- a/src/math/tiny/tiny_vector3.h
+++ b/src/math/tiny/tiny_vector3.h
@@ -144,6 +144,7 @@ namespace TINY
             res = TinyConstants::sqrt1(res);
             return res;
         }
+        inline TinyScalar norm() const { return length(); }
 
         inline TinyScalar length_squared() const {
             TinyScalar res = (*this).dot(*this);
@@ -159,6 +160,7 @@ namespace TINY
         }
 
         inline TinyScalar sqnorm() const { return m_x * m_x + m_y * m_y + m_z * m_z; }
+        inline TinyScalar squaredNorm() const { return sqnorm(); }
 
         inline TinyVector3& operator+=(const TinyVector3& v) {
             m_x += v.m_x;


### PR DESCRIPTION
Computes collision by first getting the point on the capsule-segment that is closest to the sphere-center.
Uses clamp to avoid branches.


_Secondary:_
```tiny_vector3.h```: change API according to Eigen
```geometry.hpp```: Capsule can compute the position of tip & base given the pose