### PR TITLE
Expose view and projection matrices used by TinyGLInstancingRenderer

### DIFF
--- a/python/pytinyopengl3.cc
+++ b/python/pytinyopengl3.cc
@@ -461,7 +461,25 @@ PYBIND11_MODULE(pytinyopengl3, m) {
     .def("init", &TinyGLInstancingRenderer::init)
     .def("update_camera", &TinyGLInstancingRenderer::update_camera)
     .def("get_active_camera", &TinyGLInstancingRenderer::get_active_camera2)
-    
+
+    .def_property("view_matrix",
+        [](const TinyGLInstancingRenderer& self) { 
+            std::array<float, 16> viewMatrix;
+            self.get_view_matrix(viewMatrix.data());
+            return viewMatrix;
+        },
+        [](TinyGLInstancingRenderer& self, const std::array<float, 16>& viewMatrix) {
+            self.set_view_matrix(viewMatrix.data());
+        })
+    .def_property("projection_matrix",
+        [](const TinyGLInstancingRenderer& self) { 
+            std::array<float, 16> projectionMatrix;
+            self.get_projection_matrix(projectionMatrix.data());
+            return projectionMatrix;
+        },
+        [](TinyGLInstancingRenderer& self, const std::array<float, 16>& projectionMatrix) {
+            self.set_projection_matrix(projectionMatrix.data());
+        })
     
     .def("register_shape", &TinyGLInstancingRenderer::register_shape1,
       py::arg("vertices"), py::arg("indices"), py::arg("textureIndex")=-1, py::arg("double_sided")=true)

--- a/src/visualizer/opengl/tiny_gl_instancing_renderer.cpp
+++ b/src/visualizer/opengl/tiny_gl_instancing_renderer.cpp
@@ -1609,6 +1609,38 @@ void TinyGLInstancingRenderer::update_camera(int upAxis) {
   }
 }
 
+void TinyGLInstancingRenderer::get_projection_matrix(float projMatrix[16]) const {
+  for (int i = 0; i < 16; i++) {
+    projMatrix[i] = m_data->m_projectionMatrix[i];
+  }
+}
+
+void TinyGLInstancingRenderer::set_projection_matrix(const float projMatrix[16]) {
+  for (int i = 0; i < 16; i++) {
+    m_data->m_projectionMatrix[i] = projMatrix[i];
+  }
+}
+
+void TinyGLInstancingRenderer::get_view_matrix(float viewMatrix[16]) const {
+  for (int i = 0; i < 16; i++) {
+    viewMatrix[i] = m_data->m_viewMatrix[i];
+  }
+}
+
+void TinyGLInstancingRenderer::set_view_matrix(const float viewMatrix[16]) {
+  for (int i = 0; i < 16; i++) {
+    m_data->m_viewMatrix[i] = viewMatrix[i];
+  }
+  TinyPosef tr;
+  setFromOpenGLMatrix(tr, viewMatrix);
+  tr.inverse();
+  float viewMatInverse[16];
+  getOpenGLMatrix(tr, viewMatInverse);
+  for (int i = 0; i < 16; i++) {
+    m_data->m_viewMatrixInverse[i] = viewMatInverse[i];
+  }
+}
+
 void writeTextureToPng(int textureWidth, int textureHeight,
                        const char* fileName, int numComponents) {
   assert(glGetError() == GL_NO_ERROR);
@@ -2329,9 +2361,9 @@ for (int tile = 0; tile< tiles.size();tile++)
 
   {
     //	update_camera();
-    m_data->m_activeCamera->get_camera_projection_matrix(
-        m_data->m_projectionMatrix);
-    m_data->m_activeCamera->get_camera_view_matrix(m_data->m_viewMatrix);
+    // m_data->m_activeCamera->get_camera_projection_matrix(
+    //     m_data->m_projectionMatrix);
+    // m_data->m_activeCamera->get_camera_view_matrix(m_data->m_viewMatrix);
   }
 
   assert(glGetError() == GL_NO_ERROR);

--- a/src/visualizer/opengl/tiny_gl_instancing_renderer.h
+++ b/src/visualizer/opengl/tiny_gl_instancing_renderer.h
@@ -220,6 +220,11 @@ class TinyGLInstancingRenderer {
 
   virtual void set_active_camera(TinyCamera* cam);
 
+  void get_projection_matrix(float projMatrix[16]) const;
+  void set_projection_matrix(const float projMatrix[16]);
+  void get_view_matrix(float viewMatrix[16]) const;
+  void set_view_matrix(const float viewMatrix[16]);
+
   virtual void set_light_position(const float lightPos[3]);
   virtual void set_light_position(const double lightPos[3]);
   virtual void set_shadow_map_resolution(int shadowMapResolution);

--- a/src/visualizer/opengl/tiny_gl_instancing_renderer.h
+++ b/src/visualizer/opengl/tiny_gl_instancing_renderer.h
@@ -252,6 +252,10 @@ class TinyGLInstancingRenderer {
 
   virtual void set_render_frame_buffer(unsigned int renderFrameBuffer);
 
+private:
+  ::TINY::TinyVector3f get_camera_position() const;
+  ::TINY::TinyVector3f get_camera_target() const;
+  ::TINY::TinyVector3f get_camera_forward_vector() const;
 };
 
 #endif  // GL_INSTANCING_RENDERER_H


### PR DESCRIPTION
* Expose view and projection matrices used by TinyGLInstancingRenderer as properties (readable + writable) `app.renderer.view_matrix` and `app.renderer.projection_matrix`
* Use renderer's view matrix to retrieve camera position, target, forward vectors in `render_scene_internal`